### PR TITLE
Removed useless include

### DIFF
--- a/src/extname.h
+++ b/src/extname.h
@@ -1,8 +1,6 @@
 #ifndef EXTNAME_H
 #define EXTNAME_H
 
-#include <unistd.h>
-
-const char *extname(const char *filename);
+extern const char *extname(const char *filename);
 
 #endif /* end of include guard: EXTNAME_H */


### PR DESCRIPTION
Removed unistd.h which is not used (this should also increase portability for example on windows platforms) and declared extname as extern (just for a cleaner interface :smile: )